### PR TITLE
Fix: Delete methode en doublon

### DIFF
--- a/backend/api/enfiletesbaskets/src/main/java/com/enfiletesbaskets/enfiletesbaskets/controllers/TagController.java
+++ b/backend/api/enfiletesbaskets/src/main/java/com/enfiletesbaskets/enfiletesbaskets/controllers/TagController.java
@@ -23,14 +23,6 @@ public class TagController {
     }
 
     /**
-     * Récupère un tag par son ID.
-     */
-    @GetMapping("/{id}")
-    public TagDTO getTagById(@PathVariable Long id) {
-        return tagService.getTagById(id);
-    }
-
-    /**
      * Crée un nouveau tag.
      */
     @PostMapping


### PR DESCRIPTION
Suppression d'une méthode en double dans un des controllers qui empeche le build de l'api